### PR TITLE
Added Last Will and Testament to sketch and Home Assistant sample config

### DIFF
--- a/HASS - Homeassistant/configuration.yaml
+++ b/HASS - Homeassistant/configuration.yaml
@@ -5,6 +5,9 @@ sensor:
   - platform: mqtt
     name: 'catfeeder remaining'
     state_topic: 'home/catfeeder/remaining'   
+    availability_topic: 'home/catfeeder/LWT'
+    payload_available: 'Online'
+    payload_not_available: 'Offline'
     unit_of_measurement: '%'
   - platform: template
     sensors:

--- a/catFeeder.ino
+++ b/catFeeder.ino
@@ -34,6 +34,7 @@ PubSubClient client(espClient);
 const char* lastfed_topic = "home/catfeeder/lastfed"; // UTF date
 const char* remaining_topic = "home/catfeeder/remaining"; //Remain % fix distance above
 const char* feed_topic = "home/catfeeder/feed";  // command topic
+const char* willTopic = "home/catfeeder/LWT";  // Last Will and Testiment topic
 
 // stepper
 const int steps = 200; //REPLACEME this is the number of steps of the motor for a 360° rotation.
@@ -194,7 +195,8 @@ void reconnect() {
   while (!client.connected()) {
     Serial.print("Attempting MQTT connection...");
     // Attempt to connect
-    if (client.connect(SENSORNAME, mqtt_username, mqtt_password)) {
+    if (client.connect(SENSORNAME, mqtt_username, mqtt_password, willTopic, 1, true, "Offline")) {
+      client.publish(willTopic,"Online", true);
       Serial.println("connected");
       // ... and resubscribe
       client.subscribe(feed_topic);;


### PR DESCRIPTION
Last Will and Testament (LWT) notifies the MQTT broker that the device is online.  If the device goes offline, the broker will detect that the device is unavailable (after a timeout period) and show that the device is offline.

When a device in Home Assistant is configured with an availability_topic, the device's status will be shown as unavailable if the device goes offline.

I did not add the availability_topic to the 'cats last fed mqtt' topic so it's status will not be affected if the device goes offline.  The 'catfeeder remaining' sensor can be used as a trigger to get a notification that the feeder is offline.